### PR TITLE
fixes filtering by evidence type

### DIFF
--- a/test/controllers/search_controller_test.exs
+++ b/test/controllers/search_controller_test.exs
@@ -71,4 +71,15 @@ defmodule Bep.SearchControllerTest do
     assert html_response(conn, 200) =~ "Results"
   end
 
+  @tag login_as: %{email: "email@example.com"}
+  test "Filtering by category", %{conn: conn, user: _user} do
+    search_params_1 = %{"term": "test"}
+    search_params_2 = %{"term": "test", "category": "34"}
+
+    conn_1 = post conn, search_path(conn, :filter, %{"search" => search_params_1})
+    conn_2 = post conn, search_path(conn, :filter, %{"search" => search_params_2})
+
+    assert html_response(conn_1, 200) != html_response(conn_2, 200)
+  end
+
 end

--- a/web/controllers/search_controller.ex
+++ b/web/controllers/search_controller.ex
@@ -98,7 +98,7 @@ defmodule Bep.SearchController do
     term = search_params["term"]
     id = search_params["search_id"]
 
-    data = case HTTPClient.search(term) do
+    data = case HTTPClient.search(term, search_params) do
       {:error, _} ->
         %{"total" => 0, "documents" => []}
       {:ok, res} ->


### PR DESCRIPTION
ref #238
It looks like this functionality was lost in a refactoring at some point. Added a test to make sure it doesn't happen again.