### PR TITLE
adds max age of 1 week to session cookie

### DIFF
--- a/lib/bep/endpoint.ex
+++ b/lib/bep/endpoint.ex
@@ -36,7 +36,8 @@ defmodule Bep.Endpoint do
   plug Plug.Session,
     store: :cookie,
     key: "_bep_key",
-    signing_salt: "s0y6FaZA"
+    signing_salt: "s0y6FaZA",
+    max_age: 7 * 24 * 60 * 60 # Cookie expires after 1 week
 
   plug Bep.Router
 end


### PR DESCRIPTION
ref #241
The session cookie created by phoenix by default only lasts for a session, so when the browser is closed, the cookie is deleted. 
This change adds an expiry date to the cookie, so it will last for one week