### PR TITLE
uses documentElement instead of body to detect scroll on firefox

### DIFF
--- a/web/static/js/evidence_socket.js
+++ b/web/static/js/evidence_socket.js
@@ -67,7 +67,7 @@ function scrollEvent(socket, channel) {
 
   document.addEventListener('scroll', function() {
     if (ready && parseInt(total) > (20 * page) ) {
-      if (document.body.scrollHeight == document.body.scrollTop + window.innerHeight) {
+      if (document.body.scrollHeight <= (document.body.scrollTop || document.documentElement.scrollTop) + window.innerHeight) {
         spinner.style.display = "block";
         ready = false;
         channel.push("scroll", {term: searchTerm })


### PR DESCRIPTION
ref #237
document.body.scrollTop doesn't work on firefox, so we have to use document.documentElement.scrollTop instead to detect how far the user has scrolled.