### PR TITLE
stops searches being duplicated in database

### DIFF
--- a/web/controllers/search_controller.ex
+++ b/web/controllers/search_controller.ex
@@ -52,7 +52,9 @@ defmodule Bep.SearchController do
         pubs = get_publications(user, tripdatabase_ids)
         data = link_publication_notes(data, pubs)
 
-        case Repo.get_by(Search, term: String.trim(term), user_id: user.id) do
+        trimmed_term = term |> String.trim |> String.downcase
+
+        case Repo.get_by(Search, term: trimmed_term, user_id: user.id) do
           nil ->
             changeset =
               user


### PR DESCRIPTION
If a user typed a search with an uppercase character, the function to get the search from the database would return no matches, as all the terms in the database are lowercase. This would then cause the entry to be added to the database (when it will be lowercased), meaning a search was duplicated.

When the search was then performed and the term was all lowercase, two items would be found in the database that match, causing the server to throw an error as it was only expecting one.

The solution to this is to lowercase the search term before trying to find it in the database.

This should hopefully fix https://gitub.com/dwyl/bestevidence/issues/134#issuecomment-347547930,
however we will have to manually remove the already duplicated results form the database to stop the error occurring on already duplicated searches.