### PR TITLE
Password Reset

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,11 @@ use Mix.Config
 
 # General application configuration
 config :bep,
-  ecto_repos: [Bep.Repo]
+  ecto_repos: [Bep.Repo],
+  mailgun_api_key: System.get_env("MAILGUN_API_KEY"),
+  mailgun_domain: System.get_env("MAILGUN_DOMAIN"),
+  base_url: "https://www.bestevidence.info"
+
 
 # Configures the endpoint
 config :bep, Bep.Endpoint,

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,8 @@ config :bep,
   ecto_repos: [Bep.Repo],
   mailgun_api_key: System.get_env("MAILGUN_API_KEY"),
   mailgun_domain: System.get_env("MAILGUN_DOMAIN"),
-  base_url: "https://www.bestevidence.info"
+  base_url: "https://www.bestevidence.info",
+  httpoison: HTTPoison
 
 
 # Configures the endpoint

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -42,3 +42,6 @@ config :bep, Bep.Repo,
   database: "bep_dev",
   hostname: "localhost",
   pool_size: 10
+
+config :bep,
+  base_url: "http://localhost:4000"

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,6 @@ config :bep, Bep.Repo,
   database: "bep_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :bep,
+  httpoison: Bep.Mock.HTTPoison

--- a/priv/repo/migrations/20171201100804_password_reset.exs
+++ b/priv/repo/migrations/20171201100804_password_reset.exs
@@ -1,0 +1,14 @@
+defmodule Bep.Repo.Migrations.PasswordReset do
+  use Ecto.Migration
+
+  def change do
+    create table(:password_resets) do
+      add :token, :string
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :token_expires, :utc_datetime
+
+      timestamps()
+    end
+    create index(:password_resets, [:user_id])
+  end
+end

--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -1,0 +1,72 @@
+defmodule Bep.PasswordControllerTest do
+  use Bep.ConnCase
+  alias Bep.{Repo, User, PasswordReset, PasswordController}
+
+  setup %{conn: conn} do
+    %User{}
+    |> User.registration_changeset(%{email: "test@test.com", password: "password"})
+    |> Repo.insert
+
+    {:ok, conn: conn}
+  end
+
+  test "GET /password", %{conn: conn} do
+    conn = get conn, "/password"
+    assert html_response(conn, 200) =~ "Forgotten Your Password?"
+  end
+
+  test "request reset", %{conn: _conn} do
+    assert {:ok, token} = PasswordController.gen_token("test@test.com")
+    assert Repo.get_by(PasswordReset, token: token)
+  end
+
+  test "POST password/request", %{conn: conn} do
+    conn = post conn, "/password/request", %{"email" => %{"email" => "test@test.com"}}
+    assert html_response(conn, 200)
+    assert get_flash(conn, :info) =~ "We've sent a password reset link"
+  end
+
+  test "POST password/request - bad user", %{conn: conn} do
+    conn = post conn, "/password/request", %{"email" => %{"email" => "nonuser@test.com"}}
+    assert html_response(conn, 200)
+    assert get_flash(conn, :info) =~ "We've sent a password reset link"
+  end
+
+  test "GET /password/reset", %{conn: conn} do
+    conn = get conn, "/password/reset", %{"token" => "test"}
+    assert html_response(conn, 200) =~ "Reset Your Password"
+  end
+
+  test "POST /password/reset", %{conn: conn} do
+    {:ok, token} = PasswordController.gen_token("test@test.com")
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "test@test.com", "password" => "password"}}
+    assert html_response(conn, 200)
+    assert get_flash(conn, :info) =~ "Your password has been updated"
+  end
+
+  test "POST /password/reset - bad token", %{conn: conn} do
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => "token", "email" => "test@test.com", "password" => "password"}}
+    assert html_response(conn, 200)
+    assert get_flash(conn, :error) =~ "This password reset link has expired."
+  end
+
+  test "POST /password/reset - bad user", %{conn: conn} do
+    {:ok, token} = PasswordController.gen_token("test@test.com")
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "baduser@test.com", "password" => "password"}}
+    assert html_response(conn, 200)
+    assert get_flash(conn, :error) =~ "This password reset link has expired."
+  end
+
+  test "POST /password/reset - expired token", %{conn: conn} do
+    {:ok, token} = PasswordController.gen_token("test@test.com")
+
+      Repo.get_by(PasswordReset, token: token)
+      |> PasswordReset.changeset(%{})
+      |> put_change(:token_expires, Timex.shift(Timex.now, hours: -2))
+      |> Repo.update
+
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "test@test.com", "password" => "password"}}
+    assert html_response(conn, 200)
+    assert get_flash(conn, :error) =~ "This password reset link has expired."
+  end
+end

--- a/test/support/mock_httpoison.ex
+++ b/test/support/mock_httpoison.ex
@@ -1,0 +1,5 @@
+defmodule Bep.Mock.HTTPoison do
+  def request("post", _url, _body, _headers) do
+    %{status_code: 200}
+  end
+end

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -1,0 +1,72 @@
+defmodule Bep.PasswordController do
+  use Bep.Web, :controller
+
+  @mailgun_api_key Application.get_env :bep, :mailgun_api_key
+  @mailgun_domain Application.get_env :bep, :mailgun_domain
+  @base_url Application.get_env :bep, :base_url
+
+  def index(conn, _params) do
+    render conn, "index.html"
+  end
+
+  def request(conn, %{"email" => %{"email" => email}}) do
+    conn
+    |> send_password_reset_email(email)
+    |> render("index.html")
+  end
+
+  defp send_password_reset_email(conn, email) do
+    40
+    |> gen_rand_string
+    |> send_email(email)
+    |> case do
+      {:ok, _} ->
+        conn
+        |> put_flash(:info, """
+          We've sent a password reset link to the email you entered.
+          If you don't receive an email, make sure you entered the address
+          correctly and try again
+        """)
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Something went wrong. Please try again.")
+    end
+  end
+
+  defp gen_rand_string(length) do
+    length |> :crypto.strong_rand_bytes |> Base.url_encode64
+  end
+
+  defp send_email(token, email) do
+    url = "https://api:key-#{@mailgun_api_key}@api.mailgun.net/v3/#{@mailgun_domain}/messages"
+
+    headers = [{"Content-Type", "application/x-www-form-urlencoded"}]
+
+    body = {:form, [
+      from: "Best Evidence <best.evidence.dev@gmail.com>",
+      to: email,
+      subject: "Password Reset",
+      html: """
+      <p>
+        You recently requested a password reset for your Best Evidence account.
+      </p>
+      <p>
+        To reset your password,
+        <a href="#{@base_url}/password/reset/#{token}">
+          click here
+        </a>
+        and follow the instructions.
+      </p>
+      <p>
+        If you didn't request a password reset, you can ignore this email, or
+        <a href="mailto:bestevidencefeedback@gmail.com">
+          contact our support team
+        </a>
+        if you have any questions
+      </p>
+      """
+    ]}
+
+    HTTPoison.request("post", url, body, headers)
+  end
+end

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -1,6 +1,8 @@
 defmodule Bep.PasswordController do
   use Bep.Web, :controller
 
+  alias Bep.{PasswordReset, User, Repo}
+
   @mailgun_api_key Application.get_env :bep, :mailgun_api_key
   @mailgun_domain Application.get_env :bep, :mailgun_domain
   @base_url Application.get_env :bep, :base_url
@@ -16,25 +18,41 @@ defmodule Bep.PasswordController do
   end
 
   defp send_password_reset_email(conn, email) do
-    40
-    |> gen_rand_string
-    |> send_email(email)
+    email_message = """
+      We've sent a password reset link to the email you entered.
+      If you don't receive an email, make sure you entered the address
+      correctly and try again
+    """
+
+    email
+    |> gen_token
     |> case do
-      {:ok, _} ->
-        conn
-        |> put_flash(:info, """
-          We've sent a password reset link to the email you entered.
-          If you don't receive an email, make sure you entered the address
-          correctly and try again
-        """)
-      {:error, _} ->
-        conn
-        |> put_flash(:error, "Something went wrong. Please try again.")
+      {:error, _token} -> put_flash(conn, :info, email_message)
+      {:ok, token} ->
+        token
+        |> send_email(email)
+        |> (fn _ -> put_flash(conn, :info, email_message) end).()
     end
   end
 
   defp gen_rand_string(length) do
     length |> :crypto.strong_rand_bytes |> Base.url_encode64
+  end
+
+  defp gen_token(email) do
+    token = gen_rand_string(40)
+
+    Repo.get_by(User, email: email)
+    |> case do
+      nil -> {:error, token}
+      user ->
+        user
+        |> Ecto.build_assoc(:password_resets)
+        |> PasswordReset.changeset(%{token: token})
+        |> Repo.insert!
+    end
+
+    {:ok, token}
   end
 
   defp send_email(token, email) do
@@ -52,7 +70,7 @@ defmodule Bep.PasswordController do
       </p>
       <p>
         To reset your password,
-        <a href="#{@base_url}/password/reset/#{token}">
+        <a href="#{@base_url}/password/reset?token=#{token}">
           click here
         </a>
         and follow the instructions.
@@ -68,5 +86,48 @@ defmodule Bep.PasswordController do
     ]}
 
     HTTPoison.request("post", url, body, headers)
+  end
+
+  def reset(conn, %{"token" => token}) do
+    render(conn, "reset.html", token: token)
+  end
+
+  def reset(conn, %{"reset" => %{"token" => token, "password" => password, "email" => email}}) do
+    error_message = """
+      This password reset link has expired.
+      Please request a new one <a href=\"/password\">here</a>
+    """
+    success_message = """
+      Your password has been updated. Please login <a href=\"/sessions/new\">here</a>
+    """
+
+    return_error = fn ->
+      conn |> put_flash(:error, error_message) |> render("reset.html", token: token)
+    end
+
+    case Repo.get_by(User, email: email) do
+      nil -> return_error.()
+      user ->
+        case Repo.get_by(PasswordReset, user_id: user.id, token: token) do
+          nil -> return_error.()
+          reset ->
+            if Timex.before?(Timex.now, reset.token_expires) do
+              changeset =
+                User.registration_changeset(user, %{password: password})
+                |> Repo.update
+                |> case do
+                  {:ok, _} ->
+                    Repo.delete(reset)
+                    put_flash(conn, :info, success_message)
+                  {:error, _} ->
+                    put_flash(conn, :error, error_message)
+                end
+                |> render("reset.html", token: token)
+            else
+              Repo.delete(reset)
+              return_error.()
+            end
+        end
+    end
   end
 end

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -6,6 +6,7 @@ defmodule Bep.PasswordController do
   @mailgun_api_key Application.get_env :bep, :mailgun_api_key
   @mailgun_domain Application.get_env :bep, :mailgun_domain
   @base_url Application.get_env :bep, :base_url
+  @httpoison Application.get_env :bep, :httpoison
 
   def index(conn, _params) do
     render conn, "index.html"
@@ -39,7 +40,7 @@ defmodule Bep.PasswordController do
     length |> :crypto.strong_rand_bytes |> Base.url_encode64
   end
 
-  defp gen_token(email) do
+  def gen_token(email) do
     token = gen_rand_string(40)
 
     Repo.get_by(User, email: email)
@@ -50,9 +51,9 @@ defmodule Bep.PasswordController do
         |> Ecto.build_assoc(:password_resets)
         |> PasswordReset.changeset(%{token: token})
         |> Repo.insert!
-    end
 
-    {:ok, token}
+        {:ok, token}
+    end
   end
 
   defp send_email(token, email) do
@@ -85,7 +86,7 @@ defmodule Bep.PasswordController do
       """
     ]}
 
-    HTTPoison.request("post", url, body, headers)
+    @httpoison.request("post", url, body, headers)
   end
 
   def reset(conn, %{"token" => token}) do

--- a/web/models/password_reset.ex
+++ b/web/models/password_reset.ex
@@ -1,0 +1,25 @@
+defmodule Bep.PasswordReset do
+  @moduledoc """
+  tokens for password resets
+  """
+  use Bep.Web, :model
+  alias Bep.{User}
+
+  schema "password_resets" do
+    belongs_to	:user, User
+    field :token, :string
+    field :token_expires, :utc_datetime
+    timestamps()
+  end
+
+  def changeset(model, params) do
+    model
+    |> cast(params, [:token])
+    |> validate_required([:token])
+    |> put_expiry
+  end
+
+  defp put_expiry(changeset) do
+    put_change(changeset, :token_expires, Timex.shift(Timex.now, hours: 2))
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -11,6 +11,7 @@ defmodule Bep.User do
     field :password, :string, virtual: true
     field :password_hash, :string
     has_many :searches, Search
+    has_many :password_resets, Bep.PasswordReset
     has_many :note_publications, NotePublication
     many_to_many :types, Type, join_through: UserType, on_replace: :delete
     timestamps()

--- a/web/router.ex
+++ b/web/router.ex
@@ -22,6 +22,8 @@ defmodule Bep.Router do
     resources "/sessions", SessionController, only: [:new, :create]
     resources "/consent", ConsentController, only: [:index]
     resources "/about", AboutController, only: [:index]
+    resources "/password", PasswordController, only: [:index]
+    post "/password/request", PasswordController, :request
   end
 
   scope "/", Bep do

--- a/web/router.ex
+++ b/web/router.ex
@@ -24,6 +24,8 @@ defmodule Bep.Router do
     resources "/about", AboutController, only: [:index]
     resources "/password", PasswordController, only: [:index]
     post "/password/request", PasswordController, :request
+    get "/password/reset", PasswordController, :reset
+    post "/password/reset", PasswordController, :reset
   end
 
   scope "/", Bep do

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -145,3 +145,7 @@ body {
 .add-note {
   cursor: pointer;
 }
+
+.alert:empty {
+  display: none;
+}

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -69,6 +69,10 @@ body {
   background-color: #e5f1f5;
 }
 
+.bep-bg-light-red {
+  background-color: #ff7f7f;
+}
+
 /* Placeholder text colors*/
 .bep-white-ph::-webkit-input-placeholder,
 .bep-white-ph::-moz-placeholder,

--- a/web/templates/password/index.html.eex
+++ b/web/templates/password/index.html.eex
@@ -1,0 +1,18 @@
+<section class="bep-bg-maroon tc white pt4 pb3">
+  <h1 class="f3 fw1 lh-copy pt3 mv0">Forgotten Your Password?</h1>
+</section>
+<section class="pa3 w-80 w-30-ns center">
+  <p class="f5 tc">Enter your email here, and we'll send you a link to reset your password.</p>
+  <%= form_for @conn, password_path(@conn, :request), [as: :email], fn f -> %>
+    <p class="alert alert-danger ma0" role="alert"><%= get_flash(@conn, :error) %></p>
+    <p class="alert tc ma0 pa2 bep-bg-light-blue" role="alert"><%= get_flash(@conn, :info) %></p>
+    <label for="user_email" class="db mt4">Email Address *</label>
+    <%= text_input f, :email, placeholder: "example@email.com", class: "mv2 pa2 w-100 ba br2 b--black-20" %>
+    <%= error_tag f, :email %>
+    <div class="tc pt3">
+      <%= submit "Reset Password", class: "bep-bg-maroon white ph4 pv3 ba br2 link db mb4 center pointer" %>
+      <%= link "Register a New Account", to: consent_path(@conn, :index), class: "bep-gray db mb2"%>
+      <%= link "Back to Login", to: session_path(@conn, :new), class: "bep-gray db"%>
+    </div>
+  <% end %>
+</section>

--- a/web/templates/password/reset.html.eex
+++ b/web/templates/password/reset.html.eex
@@ -1,0 +1,22 @@
+<section class="bep-bg-maroon tc white pt4 pb3">
+  <h1 class="f3 fw1 lh-copy pt3 mv0">Reset Your Password</h1>
+</section>
+<section class="pa3 w-80 w-30-ns center">
+  <p class="f5 tc">Choose a new Password</p>
+  <%= form_for @conn, password_path(@conn, :reset), [as: :reset], fn f -> %>
+    <p class="alert alert-danger pa2 ma0 bep-bg-light-red" role="alert"><%= get_flash(@conn, :error) |> raw %></p>
+    <p class="alert tc ma0 pa2 bep-bg-light-blue" role="alert"><%= get_flash(@conn, :info) |> raw %></p>
+    <label for="user_email" class="db mt4">Email Address *</label>
+    <%= email_input f, :email, placeholder: "example@email.com", class: "mv2 pa2 w-100 ba br2 b--black-20" %>
+    <%= error_tag f, :email %>
+    <label for="user_password" class="db mt4">New Password *</label>
+    <%= password_input f, :password, placeholder: "Password", class: "mv2 pa2 w-100 ba br2 b--black-20" %>
+    <%= error_tag f, :password %>
+    <%= hidden_input f, :token, value: @token %>
+    <div class="tc pt3">
+      <%= submit "Reset Password", class: "bep-bg-maroon white ph4 pv3 ba br2 link db mb4 center pointer" %>
+      <%= link "Register a New Account", to: consent_path(@conn, :index), class: "bep-gray db mb2"%>
+      <%= link "Back to Login", to: session_path(@conn, :new), class: "bep-gray db"%>
+    </div>
+  <% end %>
+</section>

--- a/web/templates/session/new.html.eex
+++ b/web/templates/session/new.html.eex
@@ -16,7 +16,8 @@
     <p class="pl1 bep-gray dib">Min 6 characters</p>
     <div class="tc pt3">
       <%= submit "Start Searching", class: "bep-bg-maroon white ph4 pv3 ba br2 link db mb4 center pointer" %>
-      <%= link "Register a New Account", to: consent_path(@conn, :index), class: "bep-gray"%>
+      <%= link "Register a New Account", to: consent_path(@conn, :index), class: "bep-gray db mb2"%>
+      <%= link "Forgotten your Password?", to: password_path(@conn, :index), class: "bep-gray db"%>
     </div>
   <% end %>
 </section>

--- a/web/views/password_view.ex
+++ b/web/views/password_view.ex
@@ -1,0 +1,3 @@
+defmodule Bep.PasswordView do
+  use Bep.Web, :view
+end


### PR DESCRIPTION
ref #246 
Adds password reset functionality.
Users can request an password reset email by entering their email into the forgotten password page. This will then show a message saying an email has been sent (whether or not their email is in our system, to avoid leaking information). 
The user, if registered, will then receive an email with a link to reset their password. The link contains a token that is also stored in the database with the users id, to verify the request to change their password.
Links are only valid for two hours, after which the user will be told to request a new one if they try to use it.