### PR TITLE
Password reset bug

### DIFF
--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -54,7 +54,7 @@ defmodule Bep.PasswordControllerTest do
 
   setup %{conn: conn} do
     %User{}
-    |> User.registration_changeset(%{email: "test@test.com", password: "password"})
+    |> User.registration_changeset(%{email: "success@simulator.amazonses.com", password: "password"})
     |> Repo.insert
 
     {:ok, conn: conn}
@@ -71,12 +71,12 @@ defmodule Bep.PasswordControllerTest do
   end
 
   test "request reset", %{conn: _conn} do
-    assert {:ok, token} = PasswordController.gen_token("test@test.com")
+    assert {:ok, token} = PasswordController.gen_token("success@simulator.amazonses.com")
     assert Repo.get_by(PasswordReset, token: token)
   end
 
   test "POST password/request", %{conn: conn} do
-    conn = post conn, "/password/request", %{"email" => %{"email" => "test@test.com"}}
+    conn = post conn, "/password/request", %{"email" => %{"email" => "success@simulator.amazonses.com"}}
     assert html_response(conn, 200)
     assert get_flash(conn, :info) =~ "We've sent a password reset link"
   end
@@ -93,34 +93,34 @@ defmodule Bep.PasswordControllerTest do
   end
 
   test "POST /password/reset", %{conn: conn} do
-    {:ok, token} = PasswordController.gen_token("test@test.com")
-    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "test@test.com", "password" => "password", "password_confirmation" => "password"}}
+    {:ok, token} = PasswordController.gen_token("success@simulator.amazonses.com")
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "success@simulator.amazonses.com", "password" => "password", "password_confirmation" => "password"}}
     assert html_response(conn, 200)
     assert get_flash(conn, :info) =~ "Your password has been updated"
   end
 
   test "POST /password/reset - passwords do not match", %{conn: conn} do
-    {:ok, token} = PasswordController.gen_token("test@test.com")
-    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "test@test.com", "password" => "password", "password_confirmation" => "something_else"}}
+    {:ok, token} = PasswordController.gen_token("success@simulator.amazonses.com")
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "success@simulator.amazonses.com", "password" => "password", "password_confirmation" => "something_else"}}
     assert html_response(conn, 200)
     assert get_flash(conn, :error) =~ "Passwords do not match"
   end
 
   test "POST /password/reset - bad token", %{conn: conn} do
-    conn = post conn, "/password/reset", %{"reset" => %{"token" => "token", "email" => "test@test.com", "password" => "password", "password_confirmation" => "password"}}
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => "token", "email" => "success@simulator.amazonses.com", "password" => "password", "password_confirmation" => "password"}}
     assert html_response(conn, 200)
     assert get_flash(conn, :error) =~ "This password reset link has expired."
   end
 
   test "POST /password/reset - bad user", %{conn: conn} do
-    {:ok, token} = PasswordController.gen_token("test@test.com")
+    {:ok, token} = PasswordController.gen_token("success@simulator.amazonses.com")
     conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "baduser@test.com", "password" => "password", "password_confirmation" => "password"}}
     assert html_response(conn, 200)
     assert get_flash(conn, :error) =~ "This link is not valid for the given email address."
   end
 
   test "POST /password/reset - expired token", %{conn: conn} do
-    {:ok, token} = PasswordController.gen_token("test@test.com")
+    {:ok, token} = PasswordController.gen_token("success@simulator.amazonses.com")
 
       PasswordReset
       |> Repo.get_by(token: token)
@@ -128,7 +128,7 @@ defmodule Bep.PasswordControllerTest do
       |> put_change(:token_expires, Timex.shift(Timex.now, hours: -2))
       |> Repo.update
 
-    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "test@test.com", "password" => "password", "password_confirmation" => "password"}}
+    conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "success@simulator.amazonses.com", "password" => "password", "password_confirmation" => "password"}}
     assert html_response(conn, 200)
     assert get_flash(conn, :error) =~ "This password reset link has expired."
   end

--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -116,7 +116,7 @@ defmodule Bep.PasswordControllerTest do
     {:ok, token} = PasswordController.gen_token("test@test.com")
     conn = post conn, "/password/reset", %{"reset" => %{"token" => token, "email" => "baduser@test.com", "password" => "password", "password_confirmation" => "password"}}
     assert html_response(conn, 200)
-    assert get_flash(conn, :error) =~ "This password reset link has expired."
+    assert get_flash(conn, :error) =~ "This link is not valid for the given email address."
   end
 
   test "POST /password/reset - expired token", %{conn: conn} do


### PR DESCRIPTION
ref #275 

This was not working due to the email being entered having an uppercase character and therefore not matching the database. 

This has been fixed by now making the email case insensitive, and by returning a more descriptive error message in cases where the email does not match.