### PR TITLE
Sprint 8 fixes

### DIFF
--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -20,7 +20,7 @@ defmodule Bep.PasswordController do
     |> render("index.html", btn_colour: btn_colour, bg_colour: bg_colour)
   end
 
-  def send_password_reset_email(conn, email, time) do
+  def send_password_reset_email(conn, email, time, client \\ nil) do
     email_message =
       """
         We've sent a password reset link to the email you entered.
@@ -34,7 +34,7 @@ defmodule Bep.PasswordController do
       {:error, _token} -> put_flash(conn, :info, email_message)
       {:ok, token} ->
         token
-        |> send_email(conn, email)
+        |> send_email(conn, email, client)
         |> (fn _ -> put_flash(conn, :info, email_message) end).()
     end
   end
@@ -61,22 +61,14 @@ defmodule Bep.PasswordController do
     end
   end
 
-  defp send_email(token, conn, email) do
+  defp send_email(token, conn, email, client) do
     url = create_link_str(conn, "#{@base_url}", "/password/reset?token=#{token}")
 
     body =
-      """
-        You recently requested a password reset for your Best Evidence account.
-
-        To reset your password, follow the link
-        #{url}
-        and follow the instructions.
-
-        If the link above does not work please copy and paste it into your browser.
-
-        If you didn't request a password reset, you can ignore this email, or
-        contact our support team via email if you have any questions bestevidencefeedback@gmail.com
-      """
+      case client == nil do
+        true -> reset_password_email_text(url)
+        _ -> set_ca_password_email_text(url, client)
+      end
 
     email
     |> Email.send_email("Best Evidence Password Reset", body)
@@ -229,5 +221,31 @@ defmodule Bep.PasswordController do
         slug ->
           "#{str1}/#{slug}#{str2}"
       end
+  end
+
+  defp reset_password_email_text(url) do
+    """
+      You recently requested a password reset for your Best Evidence account.
+
+      To reset your password, follow the link
+      #{url}
+      and follow the instructions.
+
+      If the link above does not work please copy and paste it into your browser.
+
+      If you didn't request a password reset, you can ignore this email, or
+      contact our support team via email if you have any questions bestevidencefeedback@gmail.com
+    """
+  end
+
+  defp set_ca_password_email_text(url, client) do
+    """
+      You have been made the client administrator for the #{client.name} version of the BestEvidence app.
+
+      Please create a password at the following link:
+      #{url}
+
+      Please contact Dr Amanda Burls on 07788 124 764 or email me on BestEvidenceFeedback@gmail.com if you have any questions or problems.
+    """
   end
 end

--- a/web/models/messages.ex
+++ b/web/models/messages.ex
@@ -131,6 +131,6 @@ defmodule Bep.Messages do
     query
     |> Repo.all()
     |> Repo.preload(:types)
-    |> User.filter_admin_user()
+    |> User.filter_admin_users()
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -99,7 +99,11 @@ defmodule Bep.User do
     end
   end
 
-  def filter_admin_user(users) do
-    Enum.filter(users, &!Type.is_type?(&1.types, "super-admin"))
+  def filter_admin_users(users) do
+    Enum.filter(
+      users,
+      &!Type.is_type?(&1.types, "super-admin") &&
+      !Type.is_type?(&1.types, "client-admin")
+    )
   end
 end


### PR DESCRIPTION
No longer display client admins in super admin msg users list #451
Sends client admins a different reset password email when they are set up by the super admin #452
Relates to #455 