### PR TITLE
Sprint 8 bugs

### DIFF
--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -70,8 +70,14 @@ defmodule Bep.PasswordController do
         _ -> set_ca_password_email_text(url, client)
       end
 
+    subject =
+      case client == nil do
+        true -> "Best Evidence Password Reset"
+        _ -> "You have been invited to be a BestEvidence Administrator"
+      end
+
     email
-    |> Email.send_email("Best Evidence Password Reset", body)
+    |> Email.send_email(subject, body)
     |> Mailer.deliver_now()
   end
 

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -44,7 +44,7 @@ defmodule Bep.PasswordController do
   end
 
   def gen_token(email, time) do
-    token = gen_rand_string(40)
+    token = gen_rand_string(42)
     hashed_email = User.hash_str(email)
 
     User

--- a/web/templates/messages/list_users.html.eex
+++ b/web/templates/messages/list_users.html.eex
@@ -5,6 +5,11 @@
   <%= form_for @conn, get_path(@conn).(@conn, :view_user_messages, []), [class: "tc"], fn f -> %>
     <%= text_input f, :msg_user_id, placeholder: "Search user ID", class: "w-90 w-60-l mv2 pa2 w5 ba br2 b--black-20"  %>
   <% end %>
+  <div class="mt3 mb4">
+    <%= link(to: msg_path_helper(&sa_super_admin_path/3, &search_path/3, @conn, :index), class: "no-underline b bep-gray") do %>
+      Back to main menu
+    <% end %>
+  </div>
   <%= for user <- @users do %>
     <%= link(to: msg_path_helper(&sa_messages_path/3, &messages_path/3, @conn, :view_messages, %{user: user.id})) do %>
       <div class="black mv3 pb3 bb bep-b--gray pl3">
@@ -13,8 +18,5 @@
         <i class="fa fa-chevron-right bep-maroon dib fr pr3"></i>
       </div>
     <% end %>
-  <% end %>
-  <%= link(to: msg_path_helper(&sa_super_admin_path/3, &search_path/3, @conn, :index), class: "no-underline b bep-gray") do %>
-    Back to main menu
   <% end %>
 </div>

--- a/web/templates/messages/message_sent.html.eex
+++ b/web/templates/messages/message_sent.html.eex
@@ -1,3 +1,6 @@
 <p class="pt3 tc green mt5">Message sent!</p>
-<%= link("Home", to: msg_path_helper(&sa_messages_path/3, &ca_messages_path/3, @conn, :list_users),
+<%= link("Send another message", to: msg_path_helper(&sa_messages_path/3, &ca_messages_path/3, @conn, :list_users),
+  class: "pointer db pa2 b br2 mv4 bg-green white w4 center link w5 tc") %>
+
+<%= link("Home", to: msg_path_helper(&sa_super_admin_path/3, &search_path/3, @conn, :index),
   class: "pointer db pa2 b br2 mv4 bg-green white w4 center link w5 tc") %>


### PR DESCRIPTION
Updates email subject line depending on email sent #460

Updates rand string generated so == is not always at end #460 - Not sure why but for some reason `:crypto.strong_rand_bytes(40) |> Base.url_encode64()` will always end with a `==`. @ajburls wanted this changed so I change the length given to `:crypto.strong_rand_bytes` and it has resolved the issue

Move back to main menu link to the top of the page #460

Update where home button takes users & add send another message button #460