### PR TITLE
Sprint 8 enhancements

### DIFF
--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -104,7 +104,7 @@ defmodule Bep.PasswordControllerTest do
 
   test "GET /password/reset", %{conn: conn} do
     conn = get conn, "/password/reset", %{"token" => "test"}
-    assert html_response(conn, 200) =~ "Reset Your Password"
+    assert html_response(conn, 200) =~ "Set Your Password"
   end
 
   test "POST /password/reset", %{conn: conn} do

--- a/test/views/component_helpers_test.exs
+++ b/test/views/component_helpers_test.exs
@@ -13,4 +13,8 @@ defmodule Bep.ComponentHelpersTest do
     path = ComponentHelpers.msg_link_path(conn)
     assert path == "/list-users"
   end
+
+  test "reg_user? returns false if user is client admin", %{conn: conn} do
+    assert ComponentHelpers.reg_user?(conn) == false
+  end
 end

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -45,7 +45,10 @@ defmodule Bep.PasswordController do
 
   def gen_token(email, time) do
     token = gen_rand_string(42)
-    hashed_email = User.hash_str(email)
+    hashed_email =
+      email
+      |> String.downcase()
+      |> User.hash_str()
 
     User
     |> Repo.get_by(email: hashed_email)
@@ -183,7 +186,10 @@ defmodule Bep.PasswordController do
       )
     end
 
-    hashed_email = User.hash_str(email)
+    hashed_email =
+      email
+      |> String.downcase()
+      |> User.hash_str()
 
     case Repo.get_by(User, email: hashed_email) do
       nil -> return_error.(email_error)

--- a/web/templates/component/navbar.html.eex
+++ b/web/templates/component/navbar.html.eex
@@ -10,7 +10,7 @@
 
   <%= link(to: msg_link_path(@conn), class: "dib w-25 pointer link bep-gray") do %>
     <i class="fa fa-envelope relative" aria-hidden="true">
-      <%= if @conn.assigns.message? and @conn.request_path != "/messages" do %>
+      <%= if @conn.assigns.message? and @conn.request_path != "/messages" and reg_user?(@conn) do %>
         <div class="center bg-red br4 absolute red-dot"></div>
       <% end %>
     </i>

--- a/web/templates/messages/list_users.html.eex
+++ b/web/templates/messages/list_users.html.eex
@@ -5,18 +5,20 @@
   <%= form_for @conn, get_path(@conn).(@conn, :view_user_messages, []), [class: "tc"], fn f -> %>
     <%= text_input f, :msg_user_id, placeholder: "Search user ID", class: "w-90 w-60-l mv2 pa2 w5 ba br2 b--black-20"  %>
   <% end %>
-  <div class="mt3 mb4">
+  <div class="pb4">
+    <%= for user <- @users do %>
+      <%= link(to: msg_path_helper(&sa_messages_path/3, &messages_path/3, @conn, :view_messages, %{user: user.id})) do %>
+        <div class="black mv3 pb3 bb bep-b--gray pl3">
+          <i class="fa fa-user fl dib"></i>
+          <p class="b dib ml3 mv0">User <%= user.id %></p>
+          <i class="fa fa-chevron-right bep-maroon dib fr pr3"></i>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="fixed z-5 w-100 bottom-0 bg-white h3 flex items-center">
     <%= link(to: msg_path_helper(&sa_super_admin_path/3, &search_path/3, @conn, :index), class: "no-underline b bep-gray") do %>
       Back to main menu
     <% end %>
   </div>
-  <%= for user <- @users do %>
-    <%= link(to: msg_path_helper(&sa_messages_path/3, &messages_path/3, @conn, :view_messages, %{user: user.id})) do %>
-      <div class="black mv3 pb3 bb bep-b--gray pl3">
-        <i class="fa fa-user fl dib"></i>
-        <p class="b dib ml3 mv0">User <%= user.id %></p>
-        <i class="fa fa-chevron-right bep-maroon dib fr pr3"></i>
-      </div>
-    <% end %>
-  <% end %>
 </div>

--- a/web/templates/messages/view.html.eex
+++ b/web/templates/messages/view.html.eex
@@ -33,7 +33,7 @@
   <div class="pt2 h3-l <%= ca_or_sa(@conn, "h4", "h3") %>"></div>
 <% else %>
   <div class="fixed h3-nl z-5 w-100 bep-bg-maroon bottom-3-nl bottom-0-l">
-    <p class="ph2 white">If you would like to contact Best Evidence, please <a href="mailto:bestevidencefeedback@gmail.com?subject=Feedback on BestEvidence App messaging" class="white" >email us</a> or call us on 02907 658309</p>
+    <p class="ph2 white">If you would like to contact Best Evidence, please <a href="mailto:bestevidencefeedback@gmail.com?subject=Feedback on BestEvidence App messaging" class="white" >email us</a></p>
   </div>
   <div class="h4 pt2 h3-l"></div>
 <% end %>

--- a/web/templates/messages/view.html.eex
+++ b/web/templates/messages/view.html.eex
@@ -2,7 +2,7 @@
   <%= component("admin_message_nav", [conn: @conn]) %>
 <% end %>
 
-<div class="mt4 w-80 center">
+<div class="mt4 w-80 center pb5 mb5 mb0-l">
   <div class="fixed w-80 bg-white <%= reg_or_admin(@conn, "mt5-l", "admin-msg-mt") %>">
     <div class="w-40 w-20-l tc center">
       <h3 class="bb bep-b--maroon mb0 pv2"><%= reg_or_admin(@conn, "My messages", "User #{@to_user}") %></h3>
@@ -22,18 +22,12 @@
   </div>
 </div>
 <%= if is_user_admin?(@conn) do %>
-  <div class="bg-white fixed w-100 <%= ca_or_sa(@conn, "bottom-3-nl", "bottom-0") %>">
-    <%= link(
-      "Create new message", to: msg_path_helper(
-        &sa_messages_path/3, &ca_messages_path/3, @conn, :new, [to_user: @to_user]
-      ),
-      class: "white ph4 pv3 ba br2 link db center pointer bep-bg-maroon w-70 w-40-l tc mv2")
-    %>
+  <div class="bg-white fixed w-100 bottom-0 h3 flex item-center">
+    <%= link("Create new message", to: msg_path_helper(&sa_messages_path/3, &ca_messages_path/3, @conn, :new, [to_user: @to_user]),
+      class: "white ph4 pv3 ba br2 link db center pointer bep-bg-maroon w-70 w-40-l tc mv2") %>
   </div>
-  <div class="pt2 h3-l <%= ca_or_sa(@conn, "h4", "h3") %>"></div>
 <% else %>
   <div class="fixed h3-nl z-5 w-100 bep-bg-maroon bottom-3-nl bottom-0-l">
     <p class="ph2 white">If you would like to contact Best Evidence, please <a href="mailto:bestevidencefeedback@gmail.com?subject=Feedback on BestEvidence App messaging" class="white" >email us</a></p>
   </div>
-  <div class="h4 pt2 h3-l"></div>
 <% end %>

--- a/web/templates/password/reset.html.eex
+++ b/web/templates/password/reset.html.eex
@@ -1,5 +1,5 @@
 <section style="background-color:<%= @bg_colour %>" class="bep-bg-maroon tc white pt4 pb3">
-  <h1 class="f3 fw1 lh-copy pt3 mv0">Reset Your Password</h1>
+  <h1 class="f3 fw1 lh-copy pt3 mv0">Set Your Password</h1>
 </section>
 <section class="pa3 w-80 w-30-ns center">
   <p class="f5 tc">Choose a new Password</p>

--- a/web/views/component_helpers.ex
+++ b/web/views/component_helpers.ex
@@ -83,4 +83,10 @@ defmodule Bep.ComponentHelpers do
         ""
     end
   end
+
+  def reg_user?(conn) do
+    user_type = Type.get_user_type(conn.assigns.current_user)
+
+    user_type == "regular"
+  end
 end

--- a/web/views/messages_view.ex
+++ b/web/views/messages_view.ex
@@ -2,16 +2,6 @@ defmodule Bep.MessagesView do
   use Bep.Web, :view
   alias Bep.Type
 
-  def ca_or_sa(conn, ca_var, sa_var) do
-    user_type = Type.get_user_type(conn.assigns.current_user)
-    case user_type do
-      "client-admin" ->
-        ca_var
-      _ ->
-        sa_var
-    end
-  end
-
   def reg_or_admin(conn, reg_var, admin_var) do
     user_type = Type.get_user_type(conn.assigns.current_user)
     case user_type do


### PR DESCRIPTION
Update text on reset password page #464 
Make password reset email input case insensitive #465 
Remove or `call us on ...` from the message page footer #466 
Back to main menu link is now stuck to bottom of the list users page #460
Updates position of create new message button #469 